### PR TITLE
Allow API requests with valid API keys for "Tree" resource when the instance requires login

### DIFF
--- a/app/controllers/cosmosys_controller.rb
+++ b/app/controllers/cosmosys_controller.rb
@@ -228,6 +228,9 @@ class CosmosysController < ApplicationController
     u = (params[:key] != nil) ? User.find_by_api_key(params[:key]) : User.current
 
     # Block access if the user is not allowed to see the project
+    raise ::Unauthorized unless u != nil
+    raise ::Unauthorized unless u.class.name == "User" || params[:key] != nil
+    raise ::Unauthorized unless u.class.name == "User" || params[:key] != ""
     raise ::Unauthorized unless u.allowed_to?(:csys_treeview, @project)
 
     # Do nothing if the request is not a GET

--- a/app/controllers/cosmosys_controller.rb
+++ b/app/controllers/cosmosys_controller.rb
@@ -279,6 +279,9 @@ class CosmosysController < ApplicationController
     u = (params[:key] != nil) ? User.find_by_api_key(params[:key]) : User.current
 
     # Block access if the user is not allowed to see the project
+    raise ::Unauthorized unless u != nil
+    raise ::Unauthorized unless u.class.name == "User" || params[:key] != nil
+    raise ::Unauthorized unless u.class.name == "User" || params[:key] != ""
     raise ::Unauthorized unless u.allowed_to?(:csys_treeview_commit, @project)
 
     # Do nothing if the request is a GET

--- a/app/controllers/cosmosys_controller.rb
+++ b/app/controllers/cosmosys_controller.rb
@@ -2,6 +2,7 @@ class CosmosysController < ApplicationController
   before_action :find_this_project
   before_action :authorize, :except => [:find_this_project, :treeview,:treeview_commit,:dep_gv,:hie_gv, :convert_to]
   skip_before_action :verify_authenticity_token, only: [:convert_to]
+  skip_before_action :check_if_login_required, only: [:treeview, :treeview_commit]
 
   @@tmpdir = './tmp/csys_plugin/'
 


### PR DESCRIPTION
This PR implements a few changes to allow API requests for the "Tree" resource of cosmoSys, provided by the cosmoSys controller and the component [cosmoSys Treview](https://github.com/cosmoBots/cosmosys_treeview), when the API key is valid and corresponds with an authorized user.

The problem is when an instance requires login to access to any resource, in other words, if no login, just see the login form. When the login required for everything is enabled, the API is totally blocked unless we skip the required login logic, implemented for `:treeview` and `:treeview_commit` using the method `skip_before_action` (see commit e4e89180ede9c7f68142996982fd077b2c674a9b).

However, once we disable the required login we need to handle a few more authentication cases in the same resource endpoint. If not, any user of Internet who knows that endpoint could access to all the requirements/issues just making a `GET` request. So we need to check the next conditions:

- Raises if the user is `nil`. It means the user isn't found by the backend nor by the user API key param nor the `User.current` (a connected user in the UI).
- If the user is not `nil`, it can be an `AnonymousUser` and a `User`. An `AnonymousUser` is an authorized user who makes a request to the `treeview` resource using an API key, while the `User` is the one connected in the UI.
- Raises if the user isn't a `User` and the `key` parameter of the request is `nil` or an empty string. This double check is necessary because if it is a `User` we doesn't need to check the `key` parameter of the request, if we do, the "Tree" will collide with the permissions of the current user and will raise an authorized, because the user itself in the UI doesn't have a `key` parameter in its connection. **It is the `cosmosys_treeview` who has the key**, not the user.

Same logic is applied for both resources, `:treeview` and `:treeview_commit`.

This PR is tested and I didn't find any bug nor misbehavior on this implementation.