### PR TITLE
Sag

### DIFF
--- a/app/views/cosmosys/_main_report.html.erb
+++ b/app/views/cosmosys/_main_report.html.erb
@@ -355,14 +355,13 @@ if (metadata_dict != nil) then
       <p><b><u><%= label_to_display%></u></b></p>
       <p><%= if shall_textilizable then textilizable(process_text(value_to_display_str),{:object => item}) else value_to_display_str end %></p>
       <br/>
-      <br/>
       <%
       end
     end
   }
 end
 %>
-<p>
+
 <table style="width:50%;border-style:none !important;table-layout:auto; margin-right:0px; margin-left:auto">
 <%                                                                                  #
 
@@ -488,7 +487,7 @@ end
 
 #
 %>
-</table></p>
+</table>
 <br/>
     <% end %>
 </div><%
@@ -509,11 +508,10 @@ end
 
 <%= render partial: "cosmosys/report_toolbar", locals: { flags: flags, metadata_dict: metadata_dict } %>
 <div class="<%= "cSysProject" %>">
-  <% if flags["chapnums"] %><h1><%= @project.csys.code %>: <%= @project.name %></h1><% end %>
   <%
   roots = @project.issues.select{|obj| obj.parent == nil and obj.csys.shall_report}.sort_by{|obj| obj.chapter_order}
     if roots.size == 0 then
-      roots = @project.issues.select { |n| n.parent.project != @project and n.csys.shall_report}
+      roots = @project.issues.select { |n| n.parent.project != @project and n.csys.shall_report}.sort_by{|obj| obj.chapter_order}
     end
 
     if not excluded_titles.keys.include?(title.downcase) then

--- a/app/views/cosmosys/excluded_titles/_applicable_documents.html.erb
+++ b/app/views/cosmosys/excluded_titles/_applicable_documents.html.erb
@@ -7,7 +7,7 @@
       </tr>
     </thead>
     <tbody>
-<% item.children.each{|i| %>
+<% item.children.sort_by{|obj| obj.chapter_order}.each{|i| %>
       <tr>
         <td><%= link_to i.subject, issue_path(i.id) %></td>
         <td><%= textilizable(i.description) %></td>

--- a/app/views/cosmosys/excluded_titles/_compliance_documents.html.erb
+++ b/app/views/cosmosys/excluded_titles/_compliance_documents.html.erb
@@ -7,7 +7,7 @@
       </tr>
     </thead>
     <tbody>
-<% item.children.each{|i| %>
+<% item.children.sort_by{|obj| obj.chapter_order}.each{|i| %>
       <tr>
         <td><%= link_to i.subject, issue_path(i.id) %></td>
         <td><%= textilizable(i.description) %></td>

--- a/app/views/cosmosys/excluded_titles/_deleted_requirements.html.erb
+++ b/app/views/cosmosys/excluded_titles/_deleted_requirements.html.erb
@@ -7,7 +7,7 @@
       </tr>
     </thead>
     <tbody>
-<% item.children.each{|i| %>
+<% item.children.sort_by{|obj| obj.chapter_order}.each{|i| %>
       <tr>
         <td><%= link_to i.csys.identifier, issue_path(i.id) %></td>
         <td><%= i.subject %></td>

--- a/app/views/cosmosys/excluded_titles/_list_of_abbreviations.erb
+++ b/app/views/cosmosys/excluded_titles/_list_of_abbreviations.erb
@@ -7,7 +7,7 @@
       </tr>
     </thead>
     <tbody>
-<% item.children.each{|i| %>
+<% item.children.sort_by{|obj| obj.chapter_order}.each{|i| %>
       <tr>
         <td><%= link_to i.subject, issue_path(i.id) %></td>
         <td><%= textilizable(i.description) %></td>

--- a/app/views/cosmosys/excluded_titles/_reference_documents.html.erb
+++ b/app/views/cosmosys/excluded_titles/_reference_documents.html.erb
@@ -7,7 +7,7 @@
       </tr>
     </thead>
     <tbody>
-<% item.children.each{|i| %>
+<% item.children.sort_by{|obj| obj.chapter_order}.each{|i| %>
       <tr>
         <td><%= link_to i.subject, issue_path(i.id) %></td>
         <td><%= textilizable(i.description) %></td>

--- a/app/views/cosmosys/excluded_titles/_units.erb
+++ b/app/views/cosmosys/excluded_titles/_units.erb
@@ -7,7 +7,7 @@
       </tr>
     </thead>
     <tbody>
-<% item.children.each{|i| %>
+<% item.children.sort_by{|obj| obj.chapter_order}.each{|i| %>
       <tr>
         <td><%= link_to i.subject, issue_path(i.id) %></td>
         <td><%= textilizable(i.description) %></td>

--- a/db/migrate/20250207115344_change_rel_on_close_size.rb
+++ b/db/migrate/20250207115344_change_rel_on_close_size.rb
@@ -1,0 +1,10 @@
+class ChangeRelOnCloseSize < ActiveRecord::Migration[5.2]
+  def up
+    change_column :cosmosys_issues, :relations_on_close, :text
+  end
+  def down
+    # This might cause trouble if you have strings longer
+    # than 255 characters.
+    change_column :cosmosys_issues, :relations_on_close, :string
+  end
+end


### PR DESCRIPTION
Allowing setting as RqZombie items which have a lot of relations
The relations were stored as strings (max length 256) so when there are plenty of them, system crashed.  Moved to text.